### PR TITLE
map-field

### DIFF
--- a/lib/fernet_ecto.ex
+++ b/lib/fernet_ecto.ex
@@ -12,8 +12,9 @@ defmodule Fernet.Ecto do
         use Ecto.Schema
 
         schema "person" do
-          field :name,   :string
-          field :secret, Fernet.Ecto.String
+          field :name,         :string
+          field :secret,       Fernet.Ecto.String
+          field :more_secrets, Fernet.Ecto.Map
         end
       end
 

--- a/lib/fernet_ecto/map.ex
+++ b/lib/fernet_ecto/map.ex
@@ -1,0 +1,32 @@
+defmodule Fernet.Ecto.Map do
+  @moduledoc """
+  An Ecto type for Fernet-encrypted maps.
+  """
+  import Fernet.Ecto.Type
+
+  @behaviour Ecto.Type
+
+  @doc """
+  Fernet-encrypted data is stored as a binary in the database.
+  """
+  def type, do: :binary
+
+  @doc """
+  Only accept map values.
+  """
+  def cast(map) when is_map(map), do: map
+  def cast(_), do: :error
+
+  @doc """
+  Encrypt a map to store in the database.
+  """
+  def dump(map), do: map |> :erlang.term_to_binary |> encrypt
+
+  @doc """
+  Decrypt a map loaded from the database.
+  """
+  def load(ciphertext) do
+    {:ok, decrypted} = decrypt(ciphertext)
+    {:ok, :erlang.binary_to_term(decrypted)}
+  end
+end

--- a/test/fernet_ecto/map_test.exs
+++ b/test/fernet_ecto/map_test.exs
@@ -1,0 +1,28 @@
+defmodule Fernet.Ecto.MapTest do
+  use ExUnit.Case
+
+  setup do
+    Application.ensure_all_started(:fernet_ecto)
+  end
+
+  test "Fernet.Ecto.Map.type is always :binary" do
+    assert Fernet.Ecto.Map.type == :binary
+  end
+
+  test "Fernet.Ecto.Map.cast ensures that only map values are accepted" do
+    assert Fernet.Ecto.Map.cast(%{key: :value}) == %{key: :value}
+    assert Fernet.Ecto.Map.cast("plaintext") == :error
+    assert Fernet.Ecto.Map.cast(<<"plaintext">>) == :error
+    assert Fernet.Ecto.Map.cast(:atom) == :error
+    assert Fernet.Ecto.Map.cast(1) == :error
+    assert Fernet.Ecto.Map.cast(1.0) == :error
+    assert Fernet.Ecto.Map.cast([:list]) == :error
+  end
+
+  test "Fernet.Ecto.Map.dump encrypts maps and Fernet.Ecto.Map.load decrypts ciphertext" do
+    {:ok, ciphertext} = Fernet.Ecto.Map.dump(%{key: :value})
+    assert ciphertext != %{key: :value}
+    {:ok, map} = Fernet.Ecto.Map.load(ciphertext)
+    assert map == %{key: :value}
+  end
+end


### PR DESCRIPTION
New `Fernet.Ecto.Map` implemented `Ecto.Type` to store maps as
encrypted blobs in the database.
